### PR TITLE
Add database encoding & decoding code for Nonces

### DIFF
--- a/zkabacus-crypto/Cargo.toml
+++ b/zkabacus-crypto/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Marcella Hastings <marcella@boltlabs.io>", "Shea Leffler <shea@errno
 edition = "2018"
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+sqlite = ["sqlx", "sqlx/sqlite"]
 
 [dependencies]
 zkchannels-crypto = { version = "0.1.0", path = "../zkchannels-crypto" }
@@ -14,6 +15,6 @@ ff = "0.9"
 rand_core = "0.6.0"
 rand = "0.8.3"
 serde = { version = "1", features = ["derive"] }
-sqlx = { version = "0.5.2", features = ["runtime-tokio-rustls", "sqlite"], optional = true }
+sqlx = { version = "0.5.2", features = ["runtime-tokio-rustls"], optional = true }
 thiserror = "1"
 sha3 = "0.9.1"

--- a/zkabacus-crypto/src/nonce.rs
+++ b/zkabacus-crypto/src/nonce.rs
@@ -24,7 +24,7 @@ impl Nonce {
     }
 }
 
-#[cfg(feature = "sqlx")]
+#[cfg(feature = "sqlite")]
 use sqlx::{
     database::HasArguments,
     encode::{Encode, IsNull},
@@ -32,7 +32,7 @@ use sqlx::{
     Type,
 };
 
-#[cfg(feature = "sqlx")]
+#[cfg(feature = "sqlite")]
 impl Encode<'_, Sqlite> for Nonce {
     fn encode_by_ref(&self, buf: &mut <Sqlite as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
         let bytes = self.0.to_bytes().to_vec();
@@ -45,7 +45,7 @@ impl Encode<'_, Sqlite> for Nonce {
     }
 }
 
-#[cfg(feature = "sqlx")]
+#[cfg(feature = "sqlite")]
 impl Type<Sqlite> for Nonce {
     fn type_info() -> SqliteTypeInfo {
         <Vec<u8> as Type<Sqlite>>::type_info()


### PR DESCRIPTION
This allows zeekoe to encode/decode `Nonces`. I'll use a similar approach for other types that wrap `Scalar`s.