### PR TITLE
Box all variable-length and large arrays to prevent stack overflows

### DIFF
--- a/zkchannels-crypto/src/lib.rs
+++ b/zkchannels-crypto/src/lib.rs
@@ -32,8 +32,10 @@ use ff::Field;
 use std::{iter, ops::Deref};
 
 /// Fixed-length message type used across schemes.
-#[derive(Debug, Clone, Copy)]
-pub struct Message<const N: usize>([Scalar; N]);
+///
+/// Uses Box to avoid stack overflows with long messages.
+#[derive(Debug, Clone)]
+pub struct Message<const N: usize>(Box<[Scalar; N]>);
 
 impl<const N: usize> Deref for Message<N> {
     type Target = [Scalar; N];
@@ -46,24 +48,24 @@ impl<const N: usize> Deref for Message<N> {
 impl<const N: usize> Message<N> {
     /// Create a new message from an array of scalars.
     pub fn new(scalars: [Scalar; N]) -> Self {
-        Message(scalars)
+        Message(Box::new(scalars))
     }
 
     /// Create a new message consisting of random scalars. Useful for testing purposes.
     pub fn random(rng: &mut impl Rng) -> Self {
-        Message(
+        Message(Box::new(
             iter::repeat_with(|| Scalar::random(&mut *rng))
                 .take(N)
                 .collect::<ArrayVec<_, N>>()
                 .into_inner()
                 .expect("length mismatch impossible"),
-        )
+        ))
     }
 }
 
 impl From<Scalar> for Message<1> {
     fn from(scalar: Scalar) -> Self {
-        Self([scalar])
+        Self(Box::new([scalar]))
     }
 }
 

--- a/zkchannels-crypto/src/proofs/range.rs
+++ b/zkchannels-crypto/src/proofs/range.rs
@@ -107,8 +107,10 @@ const RP_PARAMETER_L: usize = 9;
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RangeProofParameters {
     /// A signature on every `u`-ary digit
-    #[serde(with = "serde_big_array::BigArray")]
-    digit_signatures: [Signature; RP_PARAMETER_U as usize],
+    ///
+    /// Uses Box to avoid stack overflows (since U is large).
+    #[serde(with = "crate::serde::big_boxed_array")]
+    digit_signatures: Box<[Signature; RP_PARAMETER_U as usize]>,
     /// Public key corresponding _exclusively with the signatures above.
     public_key: PublicKey<1>,
 }
@@ -132,7 +134,7 @@ impl RangeProofParameters {
             .collect::<ArrayVec<_, RP_PARAMETER_U_AS_USIZE>>();
 
         Self {
-            digit_signatures: digit_signatures.into_inner().expect("known length"),
+            digit_signatures: Box::new(digit_signatures.into_inner().expect("known length")),
             public_key: keypair.public_key().clone(),
         }
     }
@@ -149,7 +151,9 @@ impl RangeProofParameters {
 #[derive(Debug)]
 pub struct RangeProofBuilder {
     /// Partially-constructed PoK of the opening of signatures on each of the digits of the value.
-    digit_proof_builders: [SignatureProofBuilder<1>; RP_PARAMETER_L],
+    ///
+    /// Uses Box to avoid stack overflows (since U is large).
+    digit_proof_builders: Box<[SignatureProofBuilder<1>; RP_PARAMETER_L]>,
     /// Commitment scalar for the value being proven in the range.
     commitment_scalar: Scalar,
 }
@@ -160,7 +164,9 @@ pub struct RangeProofBuilder {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RangeProof {
     /// Complete PoKs of the opening of a signature on each digit of the value.
-    digit_proofs: [SignatureProof<1>; RP_PARAMETER_L],
+    ///
+    /// Uses Box to avoid stack overflows (since U is large).
+    digit_proofs: Box<[SignatureProof<1>; RP_PARAMETER_L]>,
 }
 
 impl RangeProofBuilder {
@@ -192,29 +198,31 @@ impl RangeProofBuilder {
         }
 
         // Compute signature proof builders on each digit.
-        let digit_proof_builders: [SignatureProofBuilder<1>; RP_PARAMETER_L] = digits
-            .iter()
-            .map(|&digit| {
-                SignatureProofBuilder::generate_proof_commitments(
-                    rng,
-                    // N.B. u64s are being encoded to `Scalar`s using the builtin bls12_381
-                    // `From<u64>` implementation.
-                    Scalar::from(digit).into(),
-                    params.digit_signatures[digit as usize],
-                    &[None],
-                    &params.public_key,
-                )
-            })
-            .collect::<ArrayVec<_, RP_PARAMETER_L>>()
-            .into_inner()
-            .expect("impossible; len will always be RP_PARAMETER_L");
+        let digit_proof_builders: Box<[SignatureProofBuilder<1>; RP_PARAMETER_L]> = Box::new(
+            digits
+                .iter()
+                .map(|&digit| {
+                    SignatureProofBuilder::generate_proof_commitments(
+                        rng,
+                        // N.B. u64s are being encoded to `Scalar`s using the builtin bls12_381
+                        // `From<u64>` implementation.
+                        Scalar::from(digit).into(),
+                        params.digit_signatures[digit as usize],
+                        &[None],
+                        &params.public_key,
+                    )
+                })
+                .collect::<ArrayVec<_, RP_PARAMETER_L>>()
+                .into_inner()
+                .expect("impossible; len will always be RP_PARAMETER_L"),
+        );
 
         // Construct cumulative commitment scalar for value from the commitment scalars of its digits.
         let mut commitment_scalar = Scalar::zero();
         // u_pow holds the term u^j for j = 0 .. RP_PARAMETER_L
         let mut u_pow = Scalar::one();
         // Compute sum ( u^j * commitment_scalar[j] )
-        for proof_builder in &digit_proof_builders {
+        for proof_builder in &*digit_proof_builders {
             // The message here is always of length 1, so it's always okay to index it at the 0th element.
             commitment_scalar += u_pow * proof_builder.conjunction_commitment_scalars()[0];
             u_pow *= Scalar::from(RP_PARAMETER_U);
@@ -228,12 +236,14 @@ impl RangeProofBuilder {
 
     /// Run the response phase of a Schnorr-style proof of knowledge that a value is in a range.
     pub fn generate_proof_response(self, challenge: Challenge) -> RangeProof {
-        let digit_proofs = ArrayVec::from(self.digit_proof_builders)
-            .into_iter()
-            .map(|builder| builder.generate_proof_response(challenge))
-            .collect::<ArrayVec<_, RP_PARAMETER_L>>()
-            .into_inner()
-            .expect("impossible; len will always be RP_PARAMETER_L");
+        let digit_proofs = Box::new(
+            ArrayVec::from(*self.digit_proof_builders)
+                .into_iter()
+                .map(|builder| builder.generate_proof_response(challenge))
+                .collect::<ArrayVec<_, RP_PARAMETER_L>>()
+                .into_inner()
+                .expect("impossible; len will always be RP_PARAMETER_L"),
+        );
 
         RangeProof { digit_proofs }
     }
@@ -241,7 +251,7 @@ impl RangeProofBuilder {
 
 impl ChallengeInput for RangeProofBuilder {
     fn consume(&self, builder: &mut ChallengeBuilder) {
-        for digit_proof in &self.digit_proof_builders {
+        for digit_proof in &*self.digit_proof_builders {
             builder.consume(digit_proof);
         }
     }
@@ -254,7 +264,7 @@ impl RangeProof {
         params: &RangeProofParameters,
         challenge: Challenge,
     ) -> bool {
-        for proof in &self.digit_proofs {
+        for proof in &*self.digit_proofs {
             if !proof.verify_knowledge_of_signature(&params.public_key, challenge) {
                 return false;
             }
@@ -278,7 +288,7 @@ impl RangeProof {
         // u_pow holds the term u^j for j = 0 .. RP_PARAMETER_L
         let mut u_pow = Scalar::one();
         // sum ( u^j * response_scalar[j] )
-        for proof in &self.digit_proofs {
+        for proof in &*self.digit_proofs {
             response_scalar += u_pow * proof.conjunction_response_scalars()[0];
             u_pow *= Scalar::from(RP_PARAMETER_U);
         }
@@ -289,7 +299,7 @@ impl RangeProof {
 
 impl ChallengeInput for RangeProof {
     fn consume(&self, builder: &mut ChallengeBuilder) {
-        for digit_proof in &self.digit_proofs {
+        for digit_proof in &*self.digit_proofs {
             builder.consume(digit_proof);
         }
     }


### PR DESCRIPTION
Fixes #98 by boxing all arrays.