### PR TITLE
Derive Serialize/Deserialize for all customer states

### DIFF
--- a/zkabacus-crypto/src/customer.rs
+++ b/zkabacus-crypto/src/customer.rs
@@ -113,7 +113,7 @@ pub struct Ready {
 
 /// A channel that has been requested but not yet approved.
 /// This is an intermediary state of zkAbacus.Initialize.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Requested {
     config: Config,
     state: State,
@@ -123,7 +123,7 @@ pub struct Requested {
 
 /// Message sent to the merchant to request a new channel.
 /// This is sent as part of zkAbacus.Initialize.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct RequestMessage {
     /// Commitment to the initial close state.
@@ -188,7 +188,7 @@ impl Requested {
 
 /// A channel that has been approved but not yet activated.
 /// This is a channel that has completed zkAbacus.Initialize.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Inactive {
     config: Config,
     state: State,
@@ -275,7 +275,7 @@ impl Ready {
 
 /// A channel that has started a new payment.
 /// This is the first intermediary state in zkAbacus.Pay.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Started {
     config: Config,
     new_state: State,
@@ -365,7 +365,7 @@ impl Started {
 /// A channel that has made a payment but not yet been given permission by the merchant to make
 /// another payment.
 /// This is the second intermediary state of zkAbacus.Pay.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Locked {
     config: Config,
     state: State,

--- a/zkabacus-crypto/src/proofs.rs
+++ b/zkabacus-crypto/src/proofs.rs
@@ -313,7 +313,7 @@ pub struct PayProof {
 }
 
 /// Blinding factors for commitments associated with a particular payment.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct BlindingFactors {
     /// The blinding factor for a [`RevocationLockCommitment`] (associated with the previous [`State`])
     pub for_old_revocation_lock: RevocationLockBlindingFactor,

--- a/zkabacus-crypto/src/states.rs
+++ b/zkabacus-crypto/src/states.rs
@@ -381,8 +381,7 @@ pub struct CloseStateSignature(pub(crate) Signature);
 pub struct CloseStateBlindedSignature(pub(crate) BlindedSignature);
 
 /// Blinding factor for a [`CloseStateCommitment`] and corresponding [`CloseStateBlindedSignature`].
-#[derive(Debug, Clone, Copy)]
-#[allow(missing_copy_implementations)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct CloseStateBlindingFactor(pub(crate) BlindingFactor);
 
 impl CloseStateBlindedSignature {
@@ -434,7 +433,7 @@ pub struct PayToken(pub(crate) Signature);
 pub struct BlindedPayToken(BlindedSignature);
 
 /// Blinding factor for a [`StateCommitment`] and corresponding [`BlindedPayToken`]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct PayTokenBlindingFactor(pub(crate) BlindingFactor);
 
 impl BlindedPayToken {


### PR DESCRIPTION
This is necessary to keep track of customer state between the commands when a customer establishes a channel, and funds it separately. It's also good preparation for when we'll be more crash-resilient.