### PR TITLE
Add `close` method to `Inactive` struct

### DIFF
--- a/zkabacus-crypto/src/customer.rs
+++ b/zkabacus-crypto/src/customer.rs
@@ -213,6 +213,12 @@ impl Inactive {
             Failed => Err(self),
         }
     }
+
+    /// Extract data used to close the channel.
+    /// This is called as part of zkAbacus.Close.
+    pub fn close(self, rng: &mut impl Rng) -> ClosingMessage {
+        ClosingMessage::new(rng, self.close_state_signature, self.state.close_state())
+    }
 }
 
 /// Message sent to the merchant after starting a payment.


### PR DESCRIPTION
The documentation mentions that this method should exist, and it seems to be necessary for proper error handling in case of a protocol violation during channel establishment.

Specifically, the documentation says:

> The customer has the option to close at multiple points in the protocol:
>
> - **`Inactive`. A channel that hasn’t been activated can still close on the original balances.**
> - `Ready`. An activated channel can close on the current balances.
> - `Started`. After a payment has been started, the customer can close on the previous balances.
> - `Locked`. A locked channel can close on the updated balances.

 The implementation is lifted verbatim from that for the `Ready` struct.