### PR TITLE
Update merchant close state to take ref zeekoe#55

### DIFF
--- a/zkabacus-crypto/src/customer.rs
+++ b/zkabacus-crypto/src/customer.rs
@@ -174,7 +174,7 @@ impl Requested {
     ) -> Result<Inactive, Requested> {
         // Unblind close signature and verify it is correct.
         let close_state_signature = closing_signature.unblind(self.close_state_blinding_factor);
-        match close_state_signature.verify(&self.config, self.state.close_state()) {
+        match close_state_signature.verify(&self.config, &self.state.close_state()) {
             // If so, save it and enter the `Inactive` state.
             Verified => Ok(Inactive {
                 config: self.config,
@@ -345,7 +345,7 @@ impl Started {
         // Unblind close signature and verify it is correct.
         let close_state_signature =
             closing_signature.unblind(self.blinding_factors.for_close_state);
-        match close_state_signature.verify(&self.config, self.new_state.close_state()) {
+        match close_state_signature.verify(&self.config, &self.new_state.close_state()) {
             // If so, save it, reveal the revocation information for the old close signature and
             // enter the `Locked` state.
             Verified => Ok((

--- a/zkabacus-crypto/src/merchant.rs
+++ b/zkabacus-crypto/src/merchant.rs
@@ -235,13 +235,13 @@ impl Config {
 
     /// Validate closing information: make sure the [`CloseStateSignature`] is on the given
     /// [`CloseState`]. This is called as part of zkAbacus.Close.
-    ///
-    /// **Usage**: The [`CloseState`] *must* be fresh; this should only be run if the revocation
-    /// lock in the given `close_state` has never been seen before.
+    ///    
+    /// **Usage**: The [`CloseState`] *must* be fresh; this should always be accompanied by a
+    /// check that revocation lock in the given `close_state` has never been seen before.
     pub fn check_close_signature(
         &self,
         close_signature: CloseStateSignature,
-        close_state: CloseState,
+        close_state: &CloseState,
     ) -> Verification {
         // Verify the signature is on the message
         close_signature.verify(&self.to_customer_config(), close_state)

--- a/zkabacus-crypto/src/states.rs
+++ b/zkabacus-crypto/src/states.rs
@@ -412,7 +412,11 @@ impl CloseStateSignature {
     /// Verify the merchant signature against the given [`CloseState`].
     ///
     /// This is typically called by the customer.
-    pub(crate) fn verify(&self, param: &customer::Config, close_state: CloseState) -> Verification {
+    pub(crate) fn verify(
+        &self,
+        param: &customer::Config,
+        close_state: &CloseState,
+    ) -> Verification {
         param
             .merchant_public_key
             .verify(&close_state.to_message(), &self.0)


### PR DESCRIPTION
This cascades an update to a function that should take a reference instead of consuming a close state.