### PR TITLE
Expose a getter for the [`CloseState`]'s `channel_id` property.

### DIFF
--- a/zkabacus-crypto/src/states.rs
+++ b/zkabacus-crypto/src/states.rs
@@ -348,6 +348,11 @@ impl CloseState {
         ])
     }
 
+    /// Get the [`ChannelId`] for this [`CloseState`].
+    pub fn channel_id(&self) -> &ChannelId {
+        &self.channel_id
+    }
+
     /// Get the revocation lock for the [`CloseState`].
     pub fn revocation_lock(&self) -> &RevocationLock {
         &self.revocation_lock


### PR DESCRIPTION
Required by https://github.com/boltlabs-inc/zeekoe/pull/118