### PR TITLE
Add rustdoc errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,4 +37,4 @@ jobs:
         run: cargo test --all-features --doc --verbose
 
       - name: Build documentation
-        run: cargo doc --all-features --no-deps --verbose
+        run: RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features --no-deps --verbose

--- a/zkabacus-crypto/src/proofs.rs
+++ b/zkabacus-crypto/src/proofs.rs
@@ -50,9 +50,8 @@ An establish proof demonstrates that a customer is trying to initialize a channe
 This is a zero-knowledge proof that makes the following guarantees:
 
 - The new balances match the previously-agreed-upon values.
-- The [`BlindedState`] and [`BlindedCloseState`] open to objects that are correctly formed
-  relative to each other.
-- The close state is well-formed (e.g. with a close tag and corresponding to the state).
+- The channel state and close state are correctly formed relative to each other
+- The close state is well-formed (with a close tag and corresponding to the state).
 */
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EstablishProof {
@@ -256,12 +255,13 @@ A payment proof demonstrates that a customer is trying to make a valid payment o
 This is a zero-knowledge proof that makes the following guarantees:
 
 - The customer holds a valid `PayToken` and knows the state it corresponds to.
-- The customer knows the opening of the [`RevocationLockCommitment`], the [`BlindedState`], and
-  the [`BlindedCloseState`].
-- The new state from the commitment is correctly updated from the previous state
+- The customer knows a [`RevocationLock`] and the current state (and thus close state) of the
+  channel, and has correctly formed a corresponding [`CommitmentProof`] and
+  [`SignatureRequestProof`]s.
+- The new state is correctly updated from the previous state
   (that is, the balances are updated by an agreed-upon amount).
-- The close state is well-formed (e.g. with a close tag and corresponding to the new state).
-- The committed [`RevocationLock`] and revealed [`Nonce`] are contained in the previous `State`.
+- The close state is well-formed (with a close tag and corresponding to the new state).
+- The committed [`RevocationLock`] and revealed [`Nonce`] match the ones in the previous state
 - The new balances are non-negative.
 
 */


### PR DESCRIPTION
This adds a flag so that the docs correctly produce errors instead of warnings, and fixes the warnings that already existed.

fixes #184