### PR TITLE
Limit fields of the public key

### DIFF
--- a/zkabacus-crypto/src/proofs.rs
+++ b/zkabacus-crypto/src/proofs.rs
@@ -624,11 +624,12 @@ mod tests {
         merchant,
         proofs::*,
         states::{ChannelId, CustomerBalance, MerchantBalance, State},
-        RangeConstraintParameters,
     };
     use rand::SeedableRng;
-    use std::time::Instant;
     use zkchannels_crypto::pointcheval_sanders::KeyPair;
+
+    #[cfg(feature = "bincode")]
+    use {crate::RangeConstraintParameters, std::time::Instant};
 
     fn rng() -> impl Rng {
         let seed: [u8; 32] = *b"NEVER USE THIS FOR ANYTHING REAL";

--- a/zkchannels-crypto/src/pointcheval_sanders.rs
+++ b/zkchannels-crypto/src/pointcheval_sanders.rs
@@ -245,6 +245,11 @@ impl<const N: usize> PublicKey<N> {
         self.x2
     }
 
+    /// Get the y2 elements of the public key
+    pub fn y2s(&self) -> Box<[G2Affine; N]> {
+        self.y2s.clone()
+    }
+
     /// Get the g2 element of the public key
     pub fn g2(&self) -> G2Affine {
         self.g2
@@ -359,7 +364,8 @@ impl Signature {
         let h: G1Projective = random_non_identity(&mut *rng);
 
         // [x] + sum( [yi] * [mi] ), for the secret key ([x], [y1], ...) and message [m1] ...
-        let scalar_combination = signing_keypair.sk.x + inner_product(signing_keypair.sk.ys.as_ref(), msg);
+        let scalar_combination =
+            signing_keypair.sk.x + inner_product(signing_keypair.sk.ys.as_ref(), msg);
 
         Signature {
             sigma1: h.into(),

--- a/zkchannels-crypto/src/proofs/range.rs
+++ b/zkchannels-crypto/src/proofs/range.rs
@@ -292,6 +292,7 @@ mod test {
     use crate::test::rng;
     use rand::Rng;
     use std::convert::TryFrom;
+    #[cfg(feature = "bincode")]
     use std::time::Instant;
 
     #[test]

--- a/zkchannels-crypto/src/proofs/signature.rs
+++ b/zkchannels-crypto/src/proofs/signature.rs
@@ -119,10 +119,10 @@ impl<const N: usize> SignatureProof<N> {
         let commitment_proof_matches_signature = multi_miller_loop(&[
             (
                 &self.blinded_signature.sigma1(),
-                &(((params.x2 + self.commitment_proof.commitment().to_element()).to_affine())
+                &(((params.x2() + self.commitment_proof.commitment().to_element()).to_affine())
                     .into()),
             ),
-            (&self.blinded_signature.sigma2(), &params.g2.neg().into()),
+            (&self.blinded_signature.sigma2(), &params.g2().neg().into()),
         ])
         .final_exponentiation()
             == Gt::identity();


### PR DESCRIPTION
Renaming fields might make it more complicated to verify the code against the corresponding papers describing the protocol. I don't think it is very valuable to rename the fields.