### PR TITLE
Add copy docs

### DIFF
--- a/zkabacus-crypto/src/customer.rs
+++ b/zkabacus-crypto/src/customer.rs
@@ -121,19 +121,6 @@ pub struct Requested {
     pay_token_blinding_factor: PayTokenBlindingFactor,
 }
 
-/// Message sent to the merchant to request a new channel.
-/// This is sent as part of zkAbacus.Initialize.
-#[derive(Debug, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct RequestMessage {
-    /// Commitment to the initial close state.
-    pub close_state_commitment: BlindedCloseState,
-    /// Commitment to the initial state.
-    pub state_commitment: BlindedState,
-    /// Proof that channel is being correctly established.
-    pub proof: EstablishProof,
-}
-
 impl Requested {
     /**
     Generate a new channel request from public parameters.
@@ -344,9 +331,11 @@ pub struct Started {
 
 /// Message sent to the merchant to revoke the old balance and lock the channel.
 /// This is sent as part of zkAbacus.Pay.
+///
+/// This type does not derive `Clone` because the revocation information in the `LockMessage`
+/// is unique and should only be sent to a merchant once.
 #[derive(Debug)]
 #[non_exhaustive]
-#[allow(missing_copy_implementations)]
 pub struct LockMessage {
     /// Revocation pair
     pub revocation_pair: RevocationPair,

--- a/zkabacus-crypto/src/customer.rs
+++ b/zkabacus-crypto/src/customer.rs
@@ -4,9 +4,8 @@ Cryptographic routines for establishing, making payments on, and closing a zkAba
 ## Establish
 
 Channel establishment for the customer has two phases. First, the customer _initializes_ the
-channel. They form a [`RequestMessage`] that proves they have correctly formed the channel
-state with respect to the agreed-upon balances and enter the [`Requested`]
-state.
+channel. They form an [`EstablishProof`] that proves they have correctly formed the channel
+state with respect to the agreed-upon balances and enter the [`Requested`] state.
 
 On receiving a valid [`ClosingSignature`](crate::ClosingSignature), they
 [`complete()`](Requested::complete()) the initialize phase and enter the [`Inactive`] state.

--- a/zkabacus-crypto/src/lib.rs
+++ b/zkabacus-crypto/src/lib.rs
@@ -20,7 +20,7 @@ between parties in the execution of zkAbacus; these are revealed publicly.
 Ch 3.3: Off-network channel protocol zkAbacus.
 */
 #![warn(missing_docs)]
-#![warn(missing_copy_implementations, missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 #![warn(unused_qualifications, unused_results)]
 #![warn(future_incompatible)]
 #![warn(unused)]
@@ -58,8 +58,8 @@ pub type CommitmentParameters = zkchannels_crypto::pedersen::PedersenParameters<
 pub type KeyPair = zkchannels_crypto::pointcheval_sanders::KeyPair<5>;
 
 pub use states::{
-    BlindedCloseState, ChannelId, CloseState, CloseStateSignature, CustomerBalance,
-    CustomerRandomness, MerchantBalance, MerchantRandomness, VerifiedBlindedState,
+    ChannelId, CloseState, CloseStateSignature, CustomerBalance, CustomerRandomness,
+    MerchantBalance, MerchantRandomness, VerifiedBlindedState,
 };
 
 pub use revlock::RevocationLock;

--- a/zkabacus-crypto/src/lib.rs
+++ b/zkabacus-crypto/src/lib.rs
@@ -186,7 +186,7 @@ impl PaymentAmount {
     }
 }
 
-/// The "CLOSE" scalar constant, used in place of a state's nonce to form a [`BlindedCloseState`].
+/// The "CLOSE" scalar constant, used in place of a `State`'s nonce in a [`CloseState`].
 pub const CLOSE_SCALAR: Scalar = Scalar::from_raw([0, 0, 0, u64::from_le_bytes(*b"\0\0\0CLOSE")]);
 
 #[cfg(test)]

--- a/zkabacus-crypto/src/merchant.rs
+++ b/zkabacus-crypto/src/merchant.rs
@@ -55,8 +55,10 @@ use zkchannels_crypto::{
 ///
 /// Holds keys and parameters used throughout the lifetime of a merchant node, across
 /// all its channels.
+///
+/// This type does not derive `Clone` because the underlying secret key type in the
+/// [`KeyPair`] does not derive it.
 #[derive(Debug, Eq, PartialEq)]
-#[allow(missing_copy_implementations)]
 pub struct Config {
     /// KeyPair for signing, blind signing, and proofs.
     pub(crate) signing_keypair: KeyPair<5>,

--- a/zkabacus-crypto/src/revlock.rs
+++ b/zkabacus-crypto/src/revlock.rs
@@ -22,9 +22,11 @@ use {
 
 /// A verified revocation pair, which consists of a revocation secret and
 /// a corresponding revocation lock.
+///
+/// This type does not derive `Clone` because a `RevocationPair` should only be used once, to
+/// unlock a channel.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(try_from = "UncheckedRevocationPair")]
-#[allow(missing_copy_implementations)]
 pub struct RevocationPair {
     /// A revocation lock.
     lock: RevocationLock,
@@ -32,8 +34,9 @@ pub struct RevocationPair {
     secret: RevocationSecret,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
+/// This type does not derive `Copy` because it isn't used, but implementing it would not break
+/// any assumptions.
+#[derive(Debug, Serialize, Deserialize)]
 struct UncheckedRevocationPair {
     lock: RevocationLock,
     secret: UncheckedRevocationSecret,
@@ -74,8 +77,10 @@ zkchannels_crypto::impl_sqlx_for_bincode_ty!(RevocationSecret);
 ///
 /// *Binding*: Given a `RevocationLockCommitment`, an adversary cannot feasibly generate a
 /// [`RevocationLock`] and [`RevocationLockBlindingFactor`] that verify with the commitment.
+///
+/// This type does not derive `Clone`, because a `RevocationLockCommitment` must only be used
+/// once, to commit to the [`RevocationLock`] used for a payment.
 #[derive(Debug, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
 pub struct RevocationLockCommitment(pub(crate) Commitment<G1Projective>);
 
 /// Commitment randomness corresponding to a [`RevocationLockCommitment`].

--- a/zkabacus-crypto/src/states.rs
+++ b/zkabacus-crypto/src/states.rs
@@ -12,13 +12,14 @@ goes as follows:
 3. the merchant produces a blinded version of the output, and
 4. the customer unblinds the output.
 
-To produce a [`PayToken`], the customer blinds the [`State`] with a [`PayTokenBlindingFactor`].
-This produces a [`BlindedState`], which the merchant verifies with a proof to get a
+To acquire a [`PayToken`], the customer produces a proof that contains the [`State`] blinded
+with a [`PayTokenBlindingFactor`]. This is sent to the merchant, who verifies the proof to get a
 [`VerifiedBlindedState`]. Then, they blindly sign that to produce a [`BlindedPayToken`].
 
-To produce a [`CloseStateSignature`], the customer blinds the [`CloseState`] with a
-[`CloseStateBlindingFactor`]. This produces a [`BlindedCloseState`], which the merchant verifies
-to receive a [`VerifiedBlindedCloseState`], and signs to produce a [`CloseStateBlindedSignature`].
+To acquire a [`CloseStateSignature`], the customer produces a proof that contains the
+[`CloseState`] blinded with a [`CloseStateBlindingFactor`]. This is sent to the merchant, who
+verifies the proof and extracts a [`VerifiedBlindedCloseState`]. They blindly sign this to produce
+a [`CloseStateBlindedSignature`].
 
 The customer must blind the input and unblind the output with the _same_ blinding factor.
 */

--- a/zkabacus-crypto/src/states.rs
+++ b/zkabacus-crypto/src/states.rs
@@ -229,7 +229,9 @@ impl CustomerBalance {
 }
 
 /// Describes the complete state of the channel with the given ID.
-#[allow(missing_copy_implementations)]
+///
+/// This type does not implement `Clone` because a state is a unique object and should not be
+/// copied or reused.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct State {
     channel_id: ChannelId,
@@ -242,10 +244,12 @@ pub struct State {
 /// The closing state associated with a state.
 ///
 /// When signed by the merchant, this can be used by the customer to close the channel.
-/// It removes the nonce from the associated `State` to maintain privacy during closing, even in the case of
-/// merchant abort during payment.
+/// It removes the nonce from the associated `State` to maintain privacy during closing, even in
+/// the case of merchant abort during payment.
+///
+/// This type does not implement `Copy` because a close state is unique and should not be copied
+/// or reused outside the given API, except as necessary to send over the network.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
 pub struct CloseState {
     channel_id: ChannelId,
     revocation_lock: RevocationLock,
@@ -389,38 +393,33 @@ impl CloseState {
     }
 }
 
-/// Blinded representation of a State:
-/// (channel_id, nonce, revocation_lock, customer_balance, merchant_balance).
-/// The underlying State cannot be derived from this value.
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
-pub struct BlindedState(pub(crate) BlindedMessage);
-
 /// Blinded representation of a State that has been verified correct via a proof.
+///
+/// This type does not derive `Clone`; it should only be used to produce a single
+/// [`BlindedPayToken`].
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct VerifiedBlindedState(pub(crate) VerifiedBlindedMessage);
 
-/// Blinded representation of a CloseState and a constant, fixed close tag.
-///
-/// The underlying CloseState cannot be derived from this value.
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
-pub struct BlindedCloseState(pub(crate) BlindedMessage);
-
 /// Blinded representation of a State that has been verified correct via a proof.
+///
+/// This type does not derive `Clone`; it should only be used to produce a single
+/// [`BlindedCloseStateSignature`].
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct VerifiedBlindedCloseState(pub(crate) VerifiedBlindedMessage);
 
 /// Signature on a [`CloseState`] and a constant, fixed close tag. Used to close a channel.
+///
+/// This type does not derive `Copy`: it may be necessary to `Clone` a [`CloseStateSignature`]
+/// while it is valid, but it should never be used after the underlying [`CloseState`] has been
+/// revoked.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
 pub struct CloseStateSignature(Signature);
 
 /// Blinded signature on a close state and a constant, fixed close tag.
+///
+/// This type does not derive `Clone`: the blinded signature should be unblinded upon receipt,
+/// and can only be used once.
 #[derive(Debug, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
 pub struct CloseStateBlindedSignature(pub(crate) BlindedSignature);
 
 /// Blinding factor for a [`BlindedCloseState`] and corresponding [`CloseStateBlindedSignature`].
@@ -480,8 +479,10 @@ impl CloseStateSignature {
 
 /// A `PayToken` allows a customer to initiate a new payment. It is tied to a specific channel
 /// [`State`].
+///
+/// This type does not derive `Copy`: it may be necessary to `Clone` a [`PayToken`] while it is
+/// valid, but it should never be used after it has been revoked.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_copy_implementations)]
 pub struct PayToken(pub(crate) Signature);
 
 /// A blinded pay token.

--- a/zkchannels-crypto/src/lib.rs
+++ b/zkchannels-crypto/src/lib.rs
@@ -6,7 +6,7 @@
 //!   relationships, and ranges
 
 #![warn(missing_docs)]
-#![warn(missing_copy_implementations, missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 #![warn(unused_qualifications, unused_results)]
 #![warn(future_incompatible)]
 #![warn(unused)]

--- a/zkchannels-crypto/src/pointcheval_sanders.rs
+++ b/zkchannels-crypto/src/pointcheval_sanders.rs
@@ -473,8 +473,10 @@ impl BlindedMessage {
 
 /// A `VerifiedBlindedMessage` is a `BlindedMessage` for which a prover has provided a
 /// [`SignatureRequestProof`](crate::proofs::SignatureRequestProof) that verifies.
+///
+/// This type does not derive `Copy` because it should typically only be used once, to produce a
+/// [`BlindedSignature`] on the underlying message.
 #[derive(Debug, Clone)]
-#[allow(missing_copy_implementations)]
 pub struct VerifiedBlindedMessage(pub(crate) Commitment<G1Projective>);
 
 impl VerifiedBlindedMessage {

--- a/zkchannels-crypto/src/proofs/challenge.rs
+++ b/zkchannels-crypto/src/proofs/challenge.rs
@@ -71,8 +71,13 @@ impl Mul<Scalar> for Challenge {
 
 /// Holds state used when building a [`Challenge`] using the Fiat-Shamir heuristic, as in a
 /// non-interactive Schnorr proof.
+///
+/// This type does not derive `Clone` because standard use of a `Challenge` requires it to be
+/// built out of public material at time of proof verification; this prevents misuse that could
+/// arise from partially-constructed `ChallengeBuilder`s containing non-public material.
+/// Also, challenge generation is efficient and it is typically not worth reusing a
+/// `ChallengeBuilder`, even if the desired `Challenge`s consume similar inputs.
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct ChallengeBuilder {
     hasher: Sha3_256,
 }


### PR DESCRIPTION
This PR adds documentation about why some types aren't `Copy` or `Clone`.

It also removes some unused types that got refactored out of use in #150 but weren't actually removed from the library.

Closes #187