### PR TITLE
Make balances more useful

### DIFF
--- a/zkabacus-crypto/src/customer.rs
+++ b/zkabacus-crypto/src/customer.rs
@@ -173,14 +173,14 @@ impl Requested {
     /// Get the current [`CustomerBalance`] for this state.
     ///
     /// This represents the proposed customer contribution to the yet-to-be-established channel.
-    pub fn customer_balance(&self) -> &CustomerBalance {
+    pub fn customer_balance(&self) -> CustomerBalance {
         self.state.customer_balance()
     }
 
     /// Get the current [`MerchantBalance`] for this state.
     ///
     /// This represents the proposed merchant contribution to the yet-to-be-established channel.
-    pub fn merchant_balance(&self) -> &MerchantBalance {
+    pub fn merchant_balance(&self) -> MerchantBalance {
         self.state.merchant_balance()
     }
 
@@ -225,14 +225,14 @@ impl Inactive {
     /// Get the current [`CustomerBalance`] for this state.
     ///
     /// This represents the customer contribution to the yet-to-be-activated channel.
-    pub fn customer_balance(&self) -> &CustomerBalance {
+    pub fn customer_balance(&self) -> CustomerBalance {
         self.state.customer_balance()
     }
 
     /// Get the current [`MerchantBalance`] for this state.
     ///
     /// This represents the merchant contribution to the yet-to-be-activated channel.
-    pub fn merchant_balance(&self) -> &MerchantBalance {
+    pub fn merchant_balance(&self) -> MerchantBalance {
         self.state.merchant_balance()
     }
 
@@ -303,12 +303,12 @@ impl Ready {
     }
 
     /// Get the current [`CustomerBalance`] for this state, prior to starting a payment.
-    pub fn customer_balance(&self) -> &CustomerBalance {
+    pub fn customer_balance(&self) -> CustomerBalance {
         self.state.customer_balance()
     }
 
     /// Get the current [`MerchantBalance`] for this state, prior to starting a payment.
-    pub fn merchant_balance(&self) -> &MerchantBalance {
+    pub fn merchant_balance(&self) -> MerchantBalance {
         self.state.merchant_balance()
     }
 
@@ -366,12 +366,12 @@ impl ClosingMessage {
     }
 
     /// Get the closing [`CustomerBalance`] for this [`ClosingMessage`].
-    pub fn customer_balance(&self) -> &CustomerBalance {
+    pub fn customer_balance(&self) -> CustomerBalance {
         self.close_state.customer_balance()
     }
 
     /// Get the closing [`MerchantBalance`] for this [`ClosingMessage`].
-    pub fn merchant_balance(&self) -> &MerchantBalance {
+    pub fn merchant_balance(&self) -> MerchantBalance {
         self.close_state.merchant_balance()
     }
 
@@ -439,7 +439,7 @@ impl Started {
     ///
     /// Note that although the payment has been started, this is the *old* balance, because this is
     /// what would be closed on if the [`Started::close`] method was called from this state.
-    pub fn customer_balance(&self) -> &CustomerBalance {
+    pub fn customer_balance(&self) -> CustomerBalance {
         self.old_state.customer_balance()
     }
 
@@ -447,7 +447,7 @@ impl Started {
     ///
     /// Note that although the payment has been started, this is the *old* balance, because this is
     /// what would be closed on if the [`Started::close`] method was called from this state.
-    pub fn merchant_balance(&self) -> &MerchantBalance {
+    pub fn merchant_balance(&self) -> MerchantBalance {
         self.old_state.merchant_balance()
     }
 
@@ -497,7 +497,7 @@ impl Locked {
     /// Note that although the payment has not yet been completed, this is the *new* balance,
     /// because this is what would be closed on if the [`Locked::close`] method was called from this
     /// state.
-    pub fn customer_balance(&self) -> &CustomerBalance {
+    pub fn customer_balance(&self) -> CustomerBalance {
         self.state.customer_balance()
     }
 
@@ -507,7 +507,7 @@ impl Locked {
     /// Note that although the payment has not yet been completed, this is the *new* balance,
     /// because this is what would be closed on if the [`Locked::close`] method was called from this
     /// state.
-    pub fn merchant_balance(&self) -> &MerchantBalance {
+    pub fn merchant_balance(&self) -> MerchantBalance {
         self.state.merchant_balance()
     }
 

--- a/zkabacus-crypto/src/lib.rs
+++ b/zkabacus-crypto/src/lib.rs
@@ -124,7 +124,7 @@ impl BitAnd for Verification {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 struct Balance(u64);
 
 impl Balance {
@@ -134,6 +134,10 @@ impl Balance {
         } else {
             Ok(Self(value))
         }
+    }
+
+    fn zero() -> Self {
+        Self(0)
     }
 
     fn to_scalar(self) -> Scalar {

--- a/zkabacus-crypto/src/lib.rs
+++ b/zkabacus-crypto/src/lib.rs
@@ -140,6 +140,10 @@ impl Balance {
         Self(0)
     }
 
+    fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+
     fn to_scalar(self) -> Scalar {
         Scalar::from(self.0)
     }

--- a/zkabacus-crypto/src/proofs.rs
+++ b/zkabacus-crypto/src/proofs.rs
@@ -717,8 +717,8 @@ mod tests {
         // Proof must verify against the provided values.
         let public_values = EstablishProofPublicValues {
             channel_id: *state.channel_id(),
-            merchant_balance: *state.merchant_balance(),
-            customer_balance: *state.customer_balance(),
+            merchant_balance: state.merchant_balance(),
+            customer_balance: state.customer_balance(),
         };
 
         // Unwrap result - will panic if the proof is invalid.

--- a/zkabacus-crypto/src/states.rs
+++ b/zkabacus-crypto/src/states.rs
@@ -311,13 +311,13 @@ impl State {
     }
 
     /// Get the merchant's current [`MerchantBalance`] for this state.
-    pub fn merchant_balance(&self) -> &MerchantBalance {
-        &self.merchant_balance
+    pub fn merchant_balance(&self) -> MerchantBalance {
+        self.merchant_balance
     }
 
     /// Get the customer's current [`CustomerBalance`] for this state.
-    pub fn customer_balance(&self) -> &CustomerBalance {
-        &self.customer_balance
+    pub fn customer_balance(&self) -> CustomerBalance {
+        self.customer_balance
     }
 
     /// Get the current [`RevocationLock`] for this state.
@@ -414,13 +414,13 @@ impl CloseState {
     }
 
     /// Get the merchant's current [`MerchantBalance`] for this [`CloseState`].
-    pub fn merchant_balance(&self) -> &MerchantBalance {
-        &self.merchant_balance
+    pub fn merchant_balance(&self) -> MerchantBalance {
+        self.merchant_balance
     }
 
     /// Get the customer's current [`CustomerBalance`] for this [`CloseState`].
-    pub fn customer_balance(&self) -> &CustomerBalance {
-        &self.customer_balance
+    pub fn customer_balance(&self) -> CustomerBalance {
+        self.customer_balance
     }
 }
 


### PR DESCRIPTION
Adds some basic utilities for `CustomerBalance` and `MerchantBalance` per #163, including
- add functions `zero()` and `is_zero()` to create and check for zero balance
- derives `Eq` and `Ord` to easily compare balances
- adds a `try_add` function to add a customer balance to a merchant balance

It also removes a bunch of references to the types -- they both derive `Copy` and are just a single `u64` so I don't think it makes sense to return references everywhere.